### PR TITLE
Changed to use bootstrap 2.3.2

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -2,8 +2,8 @@
   "name": "ng-compass-boilerplate",
   "version": "0.0.1",
   "devDependencies": {
- 		"sass-bootstrap": "latest",
- 		"angular-bootstrap": "latest",
+ 		"sass-bootstrap": "2.3.2",
+ 		"angular-bootstrap": "0.5.0",
     "angular-ui-utils": "latest"
   }
 }


### PR DESCRIPTION
Hi there, since bower is getting sass-bootstrap 3.0 as 'latest' and ng-compass-boilerplate is using the previous bootstrap version (2.3.2), I'm doing this pull request just to fix this until we update ng-compass-boilerplate to use the bootstrap 3.0.
